### PR TITLE
Trigger Registry

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,10 @@ public class StringController implements TraceController {
     }
     return fst == snd || fst.equals(snd);
   }
+  
+  public boolean isConfigurable() {
+    return true;
+  }
 ```
 
 This controller can then be used as follows:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ try {
 SparseArray<TraceController> controllers = new SparseArray<>(1);
 
 // We want the "ExternalController" with the id specified by TRIGGER_EXTERNAL.
-controllers.put(ProfiloConstants.TRIGGER_EXTERNAL, new ExternalController());
+controllers.put(ExternalController.TRIGGER_EXTERNAL, new ExternalController());
 
 TraceOrchestrator.TraceProvider[] providers = new TraceOrchestrator.TraceProvider[] {
     new SystemCounterThread(),

--- a/java/main/com/facebook/profilo/config/BUCK
+++ b/java/main/com/facebook/profilo/config/BUCK
@@ -18,5 +18,6 @@ fb_core_android_library(
     deps = [
         profilo_path("deps/jsr-305:jsr-305"),
         profilo_path("java/main/com/facebook/profilo/core:constants"),
+        profilo_path("java/main/com/facebook/profilo/core:registry"),
     ],
 )

--- a/java/main/com/facebook/profilo/config/DefaultConfigProvider.java
+++ b/java/main/com/facebook/profilo/config/DefaultConfigProvider.java
@@ -16,7 +16,6 @@
 
 package com.facebook.profilo.config;
 
-import com.facebook.profilo.core.ProfiloConstants;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -39,12 +38,6 @@ public class DefaultConfigProvider implements ConfigProvider {
             @Override
             @Nullable
             public ControllerConfig getConfigForController(int controller) {
-              if (controller == ProfiloConstants.TRIGGER_MANUAL
-                  || controller == ProfiloConstants.TRIGGER_EXTERNAL
-                  || controller == ProfiloConstants.TRIGGER_VIDEO_PROFILER
-                  || controller == ProfiloConstants.TRIGGER_LITE) {
-                return mControllerConfig;
-              }
               return null;
             }
 

--- a/java/main/com/facebook/profilo/controllers/external/ExternalController.java
+++ b/java/main/com/facebook/profilo/controllers/external/ExternalController.java
@@ -18,9 +18,12 @@ package com.facebook.profilo.controllers.external;
 
 import com.facebook.profilo.config.ControllerConfig;
 import com.facebook.profilo.core.TraceController;
+import com.facebook.profilo.core.TriggerRegistry;
 import javax.annotation.Nullable;
 
 public class ExternalController implements TraceController {
+
+  public static final int TRIGGER_EXTERNAL = TriggerRegistry.newTrigger("external");
 
   public static class Config {
 
@@ -51,5 +54,10 @@ public class ExternalController implements TraceController {
     // Always honor stop requests.
 
     return true;
+  }
+
+  @Override
+  public boolean isConfigurable() {
+    return false;
   }
 }

--- a/java/main/com/facebook/profilo/controllers/external/api/ExternalTraceControl.java
+++ b/java/main/com/facebook/profilo/controllers/external/api/ExternalTraceControl.java
@@ -17,7 +17,6 @@
 package com.facebook.profilo.controllers.external.api;
 
 import com.facebook.profilo.controllers.external.ExternalController;
-import com.facebook.profilo.core.ProfiloConstants;
 import com.facebook.profilo.core.TraceControl;
 import com.facebook.profilo.logger.Trace;
 
@@ -39,7 +38,7 @@ public class ExternalTraceControl {
     // config in DefaultConfigProvider.
     //
     final int flags = Trace.FLAG_MANUAL;
-    return control.startTrace(ProfiloConstants.TRIGGER_EXTERNAL, flags, config, 0);
+    return control.startTrace(ExternalController.TRIGGER_EXTERNAL, flags, config, 0);
   }
 
   public static void stopTrace() {
@@ -47,6 +46,6 @@ public class ExternalTraceControl {
     if (control == null) {
       return;
     }
-    control.stopTrace(ProfiloConstants.TRIGGER_EXTERNAL, null, 0);
+    control.stopTrace(ExternalController.TRIGGER_EXTERNAL, null, 0);
   }
 }

--- a/java/main/com/facebook/profilo/core/BUCK
+++ b/java/main/com/facebook/profilo/core/BUCK
@@ -20,11 +20,13 @@ CONTROL = [
 ]
 
 REGISTRY = [
+    "GenericRegistry.java",
     "ProvidersRegistry.java",
+    "TriggerRegistry.java",
 ]
 
 fb_core_android_library(
-    name = "providersregistry",
+    name = "registry",
     srcs = REGISTRY,
     visibility = [
         "PUBLIC",
@@ -83,6 +85,7 @@ fb_core_android_library(
     ],
     deps = [
         ":constants",
+        ":registry",
         profilo_path("deps/androidinternals:os"),
         profilo_path("deps/buildconstants:buildconstants"),
         profilo_path("deps/fbtrace:utils"),
@@ -100,7 +103,7 @@ fb_core_android_library(
         ":constants",
         ":control",
         ":events",
-        ":providersregistry",
+        ":registry",
         profilo_path("java/main/com/facebook/profilo/config:config"),
         profilo_path("java/main/com/facebook/profilo/writer:writer_callbacks"),
     ],

--- a/java/main/com/facebook/profilo/core/GenericRegistry.java
+++ b/java/main/com/facebook/profilo/core/GenericRegistry.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2004-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.profilo.core;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/** Maintains a one-to-many mapping between entries of a generic type and integer identifiers. */
+final class GenericRegistry<EntryType> {
+
+  @javax.annotation.concurrent.GuardedBy("mEntries")
+  int sNextEntryBitShift = 0;
+
+  @javax.annotation.concurrent.GuardedBy("mEntries")
+  final ArrayList<EntryType> mEntries = new ArrayList<>();
+
+  /**
+   * Assigns a new integer identifier to {@code entry}.
+   *
+   * <p>You can register the same name more than once and receive unique IDs for each call.
+   */
+  public int newEntry(EntryType entry) {
+    synchronized (mEntries) {
+      if (sNextEntryBitShift >= 32) {
+        throw new IllegalStateException("Attempting to newEntry more than 32 entries.");
+      }
+      mEntries.add(entry);
+      int entryIdx = 1 << sNextEntryBitShift;
+      sNextEntryBitShift++;
+
+      return entryIdx;
+    }
+  }
+
+  /** Retrieve the bitmask for the given entry name. */
+  public int getBitMaskFor(EntryType entry) {
+    int result = 0;
+    synchronized (mEntries) {
+      int idx = 0;
+      for (EntryType registered : mEntries) {
+        if (registered.equals(entry)) {
+          result |= 1 << idx;
+        }
+        idx++;
+      }
+    }
+    return result;
+  }
+
+  /** Retrieve the bitmask for the given entries. */
+  public int getBitMaskFor(@Nullable Iterable<EntryType> entries) {
+    if (entries == null) {
+      return 0;
+    }
+    int result = 0;
+    synchronized (mEntries) {
+      for (EntryType entry : entries) {
+        result |= getBitMaskFor(entry);
+      }
+    }
+    return result;
+  }
+
+  /** Retrieve the bitmask for all registered entries */
+  public int getBitMaskForAllEntries() {
+    return getBitMaskFor(mEntries);
+  }
+
+  /** Retrieve all registered entries. */
+  public List<EntryType> getRegisteredEntries() {
+    return Collections.unmodifiableList(mEntries);
+  }
+}

--- a/java/main/com/facebook/profilo/core/ProfiloConstants.java
+++ b/java/main/com/facebook/profilo/core/ProfiloConstants.java
@@ -20,16 +20,6 @@ public final class ProfiloConstants {
 
   public static final int PROVIDER_PROFILO_SYSTEM = 0xFFFFFFFF;
 
-  public static final int TRIGGER_QPL =             1;
-  public static final int TRIGGER_MANUAL =          1 << 1;
-  public static final int TRIGGER_COLD_START =      1 << 2;
-  public static final int TRIGGER_SEQUENCE_QPL =    1 << 3;
-  public static final int TRIGGER_MULTI_PROCESS =   1 << 4;
-  public static final int TRIGGER_EXTERNAL = 1 << 5;
-  public static final int TRIGGER_BLACK_BOX = 1 << 6;
-  public static final int TRIGGER_VIDEO_PROFILER = 1 << 7;
-  public static final int TRIGGER_LITE = 1 << 8;
-
   public static final int NO_CALLSITE = 0;
   public static final int NO_MATCH = 0;
   public static final int TRACING_DISABLED = -1;

--- a/java/main/com/facebook/profilo/core/TraceController.java
+++ b/java/main/com/facebook/profilo/core/TraceController.java
@@ -43,4 +43,10 @@ public interface TraceController {
   int getCpuSamplingRateMs(Object context, ControllerConfig config);
 
   boolean contextsEqual(int fstInt, @Nullable Object fst, int sndInt, @Nullable Object snd);
+
+  /**
+   * Returns true if the controller is based on a config, and false otherwise which means hardcoded
+   * behavior.
+   */
+  boolean isConfigurable();
 }

--- a/java/main/com/facebook/profilo/core/TriggerRegistry.java
+++ b/java/main/com/facebook/profilo/core/TriggerRegistry.java
@@ -29,42 +29,43 @@ import javax.annotation.Nullable;
  * <p>The general pattern is:
  *
  * <pre>
- *   class MyProvider extends TraceOrchestrator.TraceProvider {
- *   public static final int PROVIDER_MYPROVIDER = ProviderRegistry.newProvider("myprovider");
+ *   class MyController implements TraceController {
+ *   public static final int TRIGGER_MYTRIGGER = TriggerRegistry.newTrigger("mytrigger");
  *   ...
  *   }
  * </pre>
  */
 @DoNotStrip
-public final class ProvidersRegistry {
+public final class TriggerRegistry {
   static final GenericRegistry<String> sRegistry = new GenericRegistry<>();
 
   /**
-   * Assigns a new integer identifier to {@code provider}.
+   * Assigns a new integer identifier to {@code trigger}.
    *
    * <p>You can register the same name more than once and receive unique IDs for each call.
    */
-  public static int newProvider(String provider) {
-    return sRegistry.newEntry(provider);
+  public static int newTrigger(String trigger) {
+    return sRegistry.newEntry(trigger);
   }
 
-  /**
-   * Retrieve the bitmask for the given provider name.
-   *
-   * <p>Called from JNI.
-   */
+  /** Retrieve the bitmask for the given trigger name. */
   @DoNotStrip
-  public static int getBitMaskFor(String provider) {
-    return sRegistry.getBitMaskFor(provider);
+  public static int getBitMaskFor(String trigger) {
+    return sRegistry.getBitMaskFor(trigger);
   }
 
-  /** Retrieve the bitmask for the given providers. */
-  public static int getBitMaskFor(@Nullable Iterable<String> providers) {
-    return sRegistry.getBitMaskFor(providers);
+  /** Retrieve the bitmask for the given triggers. */
+  public static int getBitMaskFor(@Nullable Iterable<String> triggers) {
+    return sRegistry.getBitMaskFor(triggers);
   }
 
-  /** Retrieve the list of the registered provider names. */
-  public static List<String> getRegisteredProviders() {
+  /** Retrieve the list of the registered trigger names. */
+  public static List<String> getRegisteredTriggers() {
     return sRegistry.getRegisteredEntries();
+  }
+
+  /** Retrieve the bitmask for the registered triggers. */
+  public static int getBitMaskForAllTriggers() {
+    return sRegistry.getBitMaskForAllEntries();
   }
 }

--- a/java/main/com/facebook/profilo/sample/BaseSampleAppMainActivity.java
+++ b/java/main/com/facebook/profilo/sample/BaseSampleAppMainActivity.java
@@ -27,7 +27,6 @@ import android.widget.ToggleButton;
 import com.facebook.profilo.BuildConfig;
 import com.facebook.profilo.controllers.external.ExternalController;
 import com.facebook.profilo.controllers.external.api.ExternalTraceControl;
-import com.facebook.profilo.core.ProfiloConstants;
 import com.facebook.profilo.core.ProvidersRegistry;
 import com.facebook.profilo.core.TraceController;
 import com.facebook.profilo.core.TraceOrchestrator;
@@ -77,7 +76,7 @@ public abstract class BaseSampleAppMainActivity extends Activity {
     }
 
     SparseArray<TraceController> controllers = new SparseArray<>(1);
-    controllers.put(ProfiloConstants.TRIGGER_EXTERNAL, new ExternalController());
+    controllers.put(ExternalController.TRIGGER_EXTERNAL, new ExternalController());
 
     TraceOrchestrator.initialize(
         this.getApplicationContext(),

--- a/java/test/com/facebook/profilo/core/TraceControlTest.java
+++ b/java/test/com/facebook/profilo/core/TraceControlTest.java
@@ -86,6 +86,7 @@ public class TraceControlTest {
         .thenReturn(PROVIDER_TEST);
     when(mController.contextsEqual(anyInt(), anyObject(), anyInt(), anyObject()))
         .thenReturn(true);
+    when(mController.isConfigurable()).thenReturn(true);
     //noinspection unchecked
     mControllers = mock(SparseArray.class);
     when(mControllers.get(eq(TRACE_CONTROLLER_ID))).thenReturn(mController);
@@ -131,6 +132,14 @@ public class TraceControlTest {
 
   @Test
   public void testStartFiltersOutControllers() {
+    TraceController secondController = mock(TraceController.class);
+    when(secondController.evaluateConfig(anyObject(), same(mControllerConfig)))
+        .thenReturn(PROVIDER_TEST);
+    when(secondController.contextsEqual(anyInt(), anyObject(), anyInt(), anyObject()))
+        .thenReturn(true);
+    when(secondController.isConfigurable()).thenReturn(true);
+    when(mControllers.get(eq(~TRACE_CONTROLLER_ID))).thenReturn(secondController);
+
     assertThat(mTraceControl.startTrace(~TRACE_CONTROLLER_ID, 0, new Object(), 0)).isFalse();
     assertNotTracing();
 
@@ -146,7 +155,28 @@ public class TraceControlTest {
   }
 
   @Test
+  public void testNonConfigurableControllerTraceStart() {
+    TraceController noConfController = mock(TraceController.class);
+    when(noConfController.evaluateConfig(anyObject(), same(mControllerConfig)))
+        .thenReturn(PROVIDER_TEST);
+    when(noConfController.contextsEqual(anyInt(), anyObject(), anyInt(), anyObject()))
+        .thenReturn(true);
+    when(noConfController.isConfigurable()).thenReturn(false);
+    when(mControllers.get(eq(~TRACE_CONTROLLER_ID))).thenReturn(noConfController);
+
+    assertThat(mTraceControl.startTrace(TRACE_CONTROLLER_ID, 0, new Object(), 0)).isTrue();
+  }
+
+  @Test
   public void testStartFromInsideTraceFails() {
+    TraceController secondController = mock(TraceController.class);
+    when(secondController.evaluateConfig(anyObject(), same(mControllerConfig)))
+        .thenReturn(PROVIDER_TEST);
+    when(secondController.contextsEqual(anyInt(), anyObject(), anyInt(), anyObject()))
+        .thenReturn(true);
+    when(secondController.isConfigurable()).thenReturn(true);
+    when(mControllers.get(eq(~TRACE_CONTROLLER_ID))).thenReturn(secondController);
+
     assertThat(mTraceControl.startTrace(TRACE_CONTROLLER_ID, 0, new Object(), 0)).isTrue();
     assertTracing();
 


### PR DESCRIPTION
Summary: Introducing `TriggerRegistry` analogous to `ProvidersRegistry` which untangles provider mapping from fixed constants.

Reviewed By: BurntBrunch

Differential Revision: D7965743

fbshipit-source-id: 9b49c7168c099781f6fa4721602a0906ea8268c4