### PR TITLE
Run buildifier in buck files in fbandroid/

### DIFF
--- a/cpp/jni/BUCK
+++ b/cpp/jni/BUCK
@@ -17,12 +17,12 @@ fb_xplat_cxx_library(
         "-std=gnu++14",
         "-DLOG_TAG=\"Profilo/Writer\"",
     ],
-    exported_deps = [
-        profilo_path("cpp/writer:writer"),
-        profilo_path("deps/fbjni:fbjni"),
-    ],
     force_static = True,
     visibility = [
         profilo_path("..."),
+    ],
+    exported_deps = [
+        profilo_path("cpp/writer:writer"),
+        profilo_path("deps/fbjni:fbjni"),
     ],
 )

--- a/cpp/logger/BUCK
+++ b/cpp/logger/BUCK
@@ -20,15 +20,15 @@ fb_xplat_cxx_library(
         "-std=gnu++14",
         "-DLOG_TAG=\"Profilo\"",
     ],
-    exported_deps = [
-        profilo_path("cpp/generated:cpp"),
-        profilo_path("cpp/logger/lfrb:lfrb"),
-    ],
     visibility = [
         profilo_path("..."),
     ],
     deps = [
         profilo_path("cpp:constants"),
+    ],
+    exported_deps = [
+        profilo_path("cpp/generated:cpp"),
+        profilo_path("cpp/logger/lfrb:lfrb"),
     ],
 )
 

--- a/cpp/museum-readonly/5.1.1/art/runtime/BUCK
+++ b/cpp/museum-readonly/5.1.1/art/runtime/BUCK
@@ -29,9 +29,6 @@ fb_xplat_cxx_library(
         "-DMUSEUM_NOOP_CHECK_MACROS",
         "-DMUSEUM_NOOP_THREAD_MUTATORS",
     ],
-    exported_deps = [
-        profilo_path("deps/museum/5.1.1/art/runtime:headers"),
-    ],
     force_static = True,
     visibility = [
         "PUBLIC",
@@ -39,5 +36,8 @@ fb_xplat_cxx_library(
     deps = [
         profilo_path("cpp/museum-readonly/5.1.1/external/libcxx:libcxx"),
         profilo_path("deps/museum:museum"),
+    ],
+    exported_deps = [
+        profilo_path("deps/museum/5.1.1/art/runtime:headers"),
     ],
 )

--- a/cpp/museum-readonly/5.1.1/external/libcxx/BUCK
+++ b/cpp/museum-readonly/5.1.1/external/libcxx/BUCK
@@ -27,9 +27,6 @@ fb_xplat_cxx_library(
         "-UMUSEUM_VERSION",
         "-DMUSEUM_VERSION=v5_1_1_readonly",
     ],
-    exported_deps = [
-        profilo_path("deps/museum/5.1.1/external/libcxx:headers"),
-    ],
     force_static = True,
     visibility = [
         "PUBLIC",
@@ -37,5 +34,8 @@ fb_xplat_cxx_library(
     deps = [
         profilo_path("deps/museum/5.1.1/bionic/libc:libc"),
         profilo_path("deps/museum:museum"),
+    ],
+    exported_deps = [
+        profilo_path("deps/museum/5.1.1/external/libcxx:headers"),
     ],
 )

--- a/cpp/museum-readonly/6.0.1/art/runtime/BUCK
+++ b/cpp/museum-readonly/6.0.1/art/runtime/BUCK
@@ -29,9 +29,6 @@ fb_xplat_cxx_library(
         "-DMUSEUM_NOOP_CHECK_MACROS",
         "-DMUSEUM_NOOP_THREAD_MUTATORS",
     ],
-    exported_deps = [
-        profilo_path("deps/museum/6.0.1/art/runtime:headers"),
-    ],
     force_static = True,
     visibility = [
         "PUBLIC",
@@ -39,5 +36,8 @@ fb_xplat_cxx_library(
     deps = [
         profilo_path("cpp/museum-readonly/6.0.1/external/libcxx:libcxx"),
         profilo_path("deps/museum:museum"),
+    ],
+    exported_deps = [
+        profilo_path("deps/museum/6.0.1/art/runtime:headers"),
     ],
 )

--- a/cpp/museum-readonly/6.0.1/external/libcxx/BUCK
+++ b/cpp/museum-readonly/6.0.1/external/libcxx/BUCK
@@ -27,9 +27,6 @@ fb_xplat_cxx_library(
         "-UMUSEUM_VERSION",
         "-DMUSEUM_VERSION=v6_0_1_readonly",
     ],
-    exported_deps = [
-        profilo_path("deps/museum/6.0.1/external/libcxx:headers"),
-    ],
     force_static = True,
     visibility = [
         "PUBLIC",
@@ -37,5 +34,8 @@ fb_xplat_cxx_library(
     deps = [
         profilo_path("deps/museum/6.0.1/bionic/libc:libc"),
         profilo_path("deps/museum:museum"),
+    ],
+    exported_deps = [
+        profilo_path("deps/museum/6.0.1/external/libcxx:headers"),
     ],
 )

--- a/cpp/museum-readonly/7.0.0/art/runtime/BUCK
+++ b/cpp/museum-readonly/7.0.0/art/runtime/BUCK
@@ -29,9 +29,6 @@ fb_xplat_cxx_library(
         "-DMUSEUM_NOOP_CHECK_MACROS",
         "-DMUSEUM_NOOP_THREAD_MUTATORS",
     ],
-    exported_deps = [
-        profilo_path("deps/museum/7.0.0/art/runtime:headers"),
-    ],
     force_static = True,
     visibility = [
         "PUBLIC",
@@ -39,5 +36,8 @@ fb_xplat_cxx_library(
     deps = [
         profilo_path("cpp/museum-readonly/7.0.0/external/libcxx:libcxx"),
         profilo_path("deps/museum:museum"),
+    ],
+    exported_deps = [
+        profilo_path("deps/museum/7.0.0/art/runtime:headers"),
     ],
 )

--- a/cpp/museum-readonly/7.0.0/external/libcxx/BUCK
+++ b/cpp/museum-readonly/7.0.0/external/libcxx/BUCK
@@ -27,9 +27,6 @@ fb_xplat_cxx_library(
         "-UMUSEUM_VERSION",
         "-DMUSEUM_VERSION=v7_0_0_readonly",
     ],
-    exported_deps = [
-        profilo_path("deps/museum/7.0.0/external/libcxx:headers"),
-    ],
     force_static = True,
     visibility = [
         "PUBLIC",
@@ -37,5 +34,8 @@ fb_xplat_cxx_library(
     deps = [
         profilo_path("deps/museum/7.0.0/bionic/libc:libc"),
         profilo_path("deps/museum:museum"),
+    ],
+    exported_deps = [
+        profilo_path("deps/museum/7.0.0/external/libcxx:headers"),
     ],
 )

--- a/cpp/writer/BUCK
+++ b/cpp/writer/BUCK
@@ -16,15 +16,15 @@ fb_xplat_cxx_library(
         "-fexceptions",
         "-DLOG_TAG=\"Profilo/Writer\"",
     ],
-    exported_deps = [
-        profilo_path("cpp/generated:cpp"),
-    ],
     preferred_linkage = "static",
     tests = [
         profilo_path("cpp/test:codegen"),
     ],
     visibility = [
         profilo_path("cpp/test/..."),
+    ],
+    exported_deps = [
+        profilo_path("cpp/generated:cpp"),
     ],
 )
 
@@ -44,15 +44,15 @@ fb_xplat_cxx_library(
         # no __builtin_sub/add_overflow on gcc 4.9, so let's do this instead
         "-fwrapv",
     ],
-    exported_deps = [
-        profilo_path("cpp/generated:cpp"),
-    ],
     preferred_linkage = "static",
     tests = [
         profilo_path("cpp/test:delta_visitor"),
     ],
     visibility = [
         profilo_path("cpp/test/..."),
+    ],
+    exported_deps = [
+        profilo_path("cpp/generated:cpp"),
     ],
 )
 
@@ -70,12 +70,12 @@ fb_xplat_cxx_library(
         "-fexceptions",
         "-DLOG_TAG=\"Profilo/Writer\"",
     ],
-    exported_deps = [
-        profilo_path("cpp/generated:cpp"),
-    ],
     preferred_linkage = "static",
     visibility = [
         profilo_path("cpp/test/..."),
+    ],
+    exported_deps = [
+        profilo_path("cpp/generated:cpp"),
     ],
 )
 
@@ -93,15 +93,15 @@ fb_xplat_cxx_library(
         "-fexceptions",
         "-DLOG_TAG=\"Profilo/Writer\"",
     ],
-    exported_deps = [
-        profilo_path("cpp/generated:cpp"),
-    ],
     preferred_linkage = "static",
     visibility = [
         profilo_path("cpp/test/..."),
     ],
     deps = [
         profilo_path("cpp/profiler:constants"),
+    ],
+    exported_deps = [
+        profilo_path("cpp/generated:cpp"),
     ],
 )
 
@@ -119,12 +119,12 @@ fb_xplat_cxx_library(
         "-fexceptions",
         "-DLOG_TAG=\"Profilo/Writer\"",
     ],
-    exported_deps = [
-        profilo_path("cpp/logger:logger"),
-    ],
     preferred_linkage = "static",
     visibility = [
         profilo_path("cpp/test/..."),
+    ],
+    exported_deps = [
+        profilo_path("cpp/logger:logger"),
     ],
 )
 
@@ -150,9 +150,6 @@ fb_xplat_cxx_library(
         "-fexceptions",
         "-DLOG_TAG=\"Profilo/Writer\"",
     ],
-    exported_deps = [
-        profilo_path("cpp/generated:cpp"),
-    ],
     preferred_linkage = "static",
     tests = [
         profilo_path("cpp/test:trace_writer"),
@@ -169,5 +166,8 @@ fb_xplat_cxx_library(
         ":timestamp_truncating_visitor",
         profilo_path("cpp/logger:logger"),
         profilo_path("deps/zstr:zstr"),
+    ],
+    exported_deps = [
+        profilo_path("cpp/generated:cpp"),
     ],
 )

--- a/java/main/com/facebook/profilo/controllers/external/api/BUCK
+++ b/java/main/com/facebook/profilo/controllers/external/api/BUCK
@@ -5,9 +5,6 @@ load("//buck_imports:profilo_path.bzl", "profilo_path")
 fb_core_android_library(
     name = "api",
     srcs = glob(["*.java"]),
-    exported_deps = [
-        profilo_path("java/main/com/facebook/profilo/core:constants"),
-    ],
     visibility = [
         "PUBLIC",
     ],
@@ -15,5 +12,8 @@ fb_core_android_library(
         profilo_path("deps/jsr-305:jsr-305"),
         profilo_path("java/main/com/facebook/profilo/controllers/external:external"),
         profilo_path("java/main/com/facebook/profilo/core:core"),
+    ],
+    exported_deps = [
+        profilo_path("java/main/com/facebook/profilo/core:constants"),
     ],
 )

--- a/java/main/com/facebook/profilo/core/BUCK
+++ b/java/main/com/facebook/profilo/core/BUCK
@@ -52,9 +52,6 @@ fb_core_android_library(
 fb_core_android_library(
     name = "events",
     srcs = EVENTS,
-    exported_deps = [
-        ":constants",
-    ],
     visibility = [
         "//javatests/com/facebook/profilo/...",
         profilo_path("..."),
@@ -64,17 +61,14 @@ fb_core_android_library(
         profilo_path("deps/jsr-305:jsr-305"),
         profilo_path("deps/soloader:soloader"),
     ],
+    exported_deps = [
+        ":constants",
+    ],
 )
 
 fb_core_android_library(
     name = "control",
     srcs = CONTROL,
-    exported_deps = [
-        ":constants",
-        profilo_path("aidl:aidl"),
-        profilo_path("java/main/com/facebook/profilo/config:config"),
-        profilo_path("java/main/com/facebook/profilo/logger:logger"),
-    ],
     required_for_source_only_abi = True,
     visibility = [
         profilo_path("..."),
@@ -91,6 +85,12 @@ fb_core_android_library(
         profilo_path("deps/fbtrace:utils"),
         profilo_path("deps/jsr-305:jsr-305"),
     ],
+    exported_deps = [
+        ":constants",
+        profilo_path("aidl:aidl"),
+        profilo_path("java/main/com/facebook/profilo/config:config"),
+        profilo_path("java/main/com/facebook/profilo/logger:logger"),
+    ],
 )
 
 fb_core_android_library(
@@ -99,14 +99,6 @@ fb_core_android_library(
         ["*.java"],
         exclude = CONSTANTS + EVENTS + CONTROL + REGISTRY,
     ),
-    exported_deps = [
-        ":constants",
-        ":control",
-        ":events",
-        ":registry",
-        profilo_path("java/main/com/facebook/profilo/config:config"),
-        profilo_path("java/main/com/facebook/profilo/writer:writer_callbacks"),
-    ],
     tests = [
         profilo_path("java/test/com/facebook/profilo/core:core"),
     ],
@@ -127,5 +119,13 @@ fb_core_android_library(
         profilo_path("deps/jsr-305:jsr-305"),
         profilo_path("deps/zip:zip"),
         profilo_path("java/main/com/facebook/profilo/logger:logger"),
+    ],
+    exported_deps = [
+        ":constants",
+        ":control",
+        ":events",
+        ":registry",
+        profilo_path("java/main/com/facebook/profilo/config:config"),
+        profilo_path("java/main/com/facebook/profilo/writer:writer_callbacks"),
     ],
 )

--- a/java/main/com/facebook/profilo/logger/BUCK
+++ b/java/main/com/facebook/profilo/logger/BUCK
@@ -5,9 +5,6 @@ load("//buck_imports:profilo_path.bzl", "profilo_path")
 fb_core_android_library(
     name = "logger",
     srcs = glob(["*.java"]),
-    exported_deps = [
-        profilo_path("cpp/generated:java"),
-    ],
     tests = [
         profilo_path("java/test/com/facebook/profilo/logger:logger"),
     ],
@@ -28,5 +25,8 @@ fb_core_android_library(
         profilo_path("java/main/com/facebook/profilo/core:constants"),
         profilo_path("java/main/com/facebook/profilo/core:events"),
         profilo_path("java/main/com/facebook/profilo/writer:writer"),
+    ],
+    exported_deps = [
+        profilo_path("cpp/generated:java"),
     ],
 )

--- a/java/main/com/facebook/profilo/writer/BUCK
+++ b/java/main/com/facebook/profilo/writer/BUCK
@@ -10,9 +10,6 @@ fb_core_android_library(
         ["*.java"],
         exclude = CALLBACKS_SRC,
     ),
-    exported_deps = [
-        ":writer_callbacks",
-    ],
     visibility = [
         profilo_path("..."),
     ],
@@ -22,6 +19,9 @@ fb_core_android_library(
         profilo_path("deps/jsr-305:jsr-305"),
         profilo_path("deps/proguard:annotations"),
         profilo_path("deps/soloader:soloader"),
+    ],
+    exported_deps = [
+        ":writer_callbacks",
     ],
 )
 


### PR DESCRIPTION
Summary:
Fixup after changing buildifier field ordering placing exported_deps after
deps.

This diff fixes up rest of the buck files in fbandroid.

drop-conflicts
bypass-lint

Reviewed By: zertosh

Differential Revision: D8151644

fbshipit-source-id: fbebb393b11e1d3f9349b128e74029657cf2dca4